### PR TITLE
ci: compile source files before release them

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm test
+      - run: npm run build
       - run: npx semantic-release --branches main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ echo 'extends: ["@apisyouwonthate/style-guide"]' > .spectral.yaml
 _If you're using VS Code or Stoplight Studio then the NPM modules will not be available. Instead you can use the CDN hosted version:_
 
 ```
-echo 'extends: ["https://unpkg.com/@apisyouwonthate/style-guide@1.1/ruleset.js"]' > .spectral.yaml
+echo 'extends: ["https://unpkg.com/@apisyouwonthate/style-guide@1.1/dist/ruleset.js"]' > .spectral.yaml
 ```
 
 Next, use Spectral CLI to lint against your OpenAPI description. Don't have any OpenAPI? [Record some HTTP traffic to make OpenAPI](https://apisyouwonthate.com/blog/creating-openapi-from-http-traffic) and then you can switch to API Design-First going forwards.

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@apisyouwonthate/style-guide",
   "version": "0.0.0",
   "description": "Make your HTTP APIs better, faster, stronger, whether they are still being designed (API Design-First) or your organization has flopped various mismatched APIs into production and now you're thinking some consistency would be nice. Using Spectral and OpenAPI.",
-  "main": "src/ruleset.ts",
+  "main": "dist/ruleset.js",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest"
   },
   "repository": {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Add a build script to compile the Typescript files to Javascript before running semantic-release

FIX #28 