### PR TITLE
fix: amend CommonJS output to be compatible with `require`

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
     "dts": true,
     "format": ["cjs", "esm"],
     "sourcemap": true,
-    "noExternal": ["@stoplight/types"]
+    "noExternal": ["@stoplight/types"],
+    "footer": {
+      "js": "module.exports = module.exports.default;"
+    }
   }
 }


### PR DESCRIPTION
Add `module.exports = module.exports.default;` at the end of the CJS file.

Fix #32

Sorry to still adding PRs to fix the errors caused by #30 I wasn't able to detect the errors in the build results until a new release is published