### PR TITLE
Update MIME type of health checks to match latest draft

### DIFF
--- a/__tests__/api-health-format.test.ts
+++ b/__tests__/api-health-format.test.ts
@@ -26,7 +26,7 @@ const template = (contentType: string) => {
 testRule("api-health-format", [
   {
     name: "valid case",
-    document: template("application/vnd.health+json"),
+    document: template("application/health+json"),
     errors: [],
   },
 

--- a/__tests__/api-health-format.test.ts
+++ b/__tests__/api-health-format.test.ts
@@ -36,7 +36,7 @@ testRule("api-health-format", [
     errors: [
       {
         message:
-          "Health path (`/heath`) SHOULD support Health Check Response Format",
+          "Health path (`/health`) SHOULD support Health Check Response Format",
         path: [
           "paths",
           "/health",
@@ -57,7 +57,7 @@ testRule("api-health-format", [
     errors: [
       {
         message:
-          "Health path (`/heath`) SHOULD support Health Check Response Format",
+          "Health path (`/health`) SHOULD support Health Check Response Format",
         path: [
           "paths",
           "/health",

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -57,7 +57,7 @@ export default {
     // Author: Phil Sturgeon (https://github.com/philsturgeon)
     "api-health-format": {
       message:
-        "Health path (`/heath`) SHOULD support Health Check Response Format",
+        "Health path (`/health`) SHOULD support Health Check Response Format",
       description:
         "Use existing standards (and draft standards) wherever possible, like the draft standard for health checks: https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check. To learn more about health check endpoints see https://apisyouwonthate.com/blog/health-checks-with-kubernetes.",
       formats: [oas3],

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -65,7 +65,7 @@ export default {
       then: {
         function: enumeration,
         functionOptions: {
-          values: ["application/vnd.health+json"],
+          values: ["application/health+json"],
         },
       },
       severity: DiagnosticSeverity.Warning,


### PR DESCRIPTION
Hi! 👋

I'm submitting this PR for a couple of small fixes:

### Changes:
1. **Typo Correction**: Fixed the typo `"heath"` to `"health"` in error messages in `api-health-format.test.ts` and `ruleset.ts`.
2. **MIME Type Update**: Updated the MIME type from `application/vnd.health+json` to `application/health+json` to align with the current [Health Check Response Format Draft Specification](https://datatracker.ietf.org/doc/html/draft-inadarei-api-health-check).

### Files Changed:
- `__tests__/api-health-format.test.ts`
- `src/ruleset.ts`

Please let me know if any adjustments are needed. Thank you for your time!

Kind regards,  

Harry